### PR TITLE
ci: guard broken grunt workflow

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -2,9 +2,9 @@ name: NodeJS with Grunt
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
   pull_request:
-    branches: [ "main" ]
+    branches: [main]
 
 jobs:
   build:
@@ -15,14 +15,18 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Build
-      run: |
-        npm install
-        grunt
+      - name: Build
+        run: |
+          if [ ! -f package.json ]; then
+            echo "No package.json at repo root; skipping grunt build."
+            exit 0
+          fi
+          npm ci
+          npx grunt


### PR DESCRIPTION
## Summary
- Make `.github/workflows/npm-grunt.yml` non-fatal when the repo has no root `package.json` and clean up YAML formatting.

## Testing
- GitHub Actions only.

## Security
- CI-only change.
